### PR TITLE
marionette updates part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ server/virtualenv
 *.pyc
 server/secret.key
 server/config.conf
+server/robots.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ server/virtualenv
 .*
 *.pyc
 server/secret.key
+server/config.conf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Marionette
 Twitch extension for controlling robots remotely
 
+### Warning: This code only supports one streamer with one robot per server
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@ Twitch extension for controlling robots remotely
 
 # Installation
 
-    cd server
-    virtualenv virtualenv
-    pip3 install -r requirements.txt
+```
+$ git clone https://github.com/strangeparts/marionette
+$ cd marionette/server
+$ virtualenv virtualenv
+```
+On linux do: `$ source virtualenv/bin/activate`
+```
+(virtualenv)$ pip3 install -r requirements.txt
+```
 
 # Run development server
 
-    gunicorn -k flask_sockets.worker --threads 5 --workers 5 -b '0.0.0.0:8000' app:app
+On linux do: `$ source virtualenv/bin/activate`
+```
+(virtualenv)$ QUART_DEBUG=1 QUART_APP=quartapp.py quart run --host 0.0.0.0 --port 8000
+```

--- a/frontend/viewer.js
+++ b/frontend/viewer.js
@@ -3,6 +3,7 @@ let tuid = '';
 
 const twitch = window.Twitch.ext;
 const buttons = ['l', 'r', 'f', 'b', 'tl', 'tr', 'CAMDOWN', 'CAMRESET', 'CAMUP'];
+const server = location.protocol + '//localhost:8000'
 
 twitch.onContext(function (context) {
   twitch.rig.log(context);
@@ -30,7 +31,7 @@ function createRequest (type, command) {
   twitch.rig.log('createRequest(' + type + ", " + command + ")");
   return {
     type: type,
-    url: location.protocol + '//localhost:8000/command?command=' + command,
+    url: server + '/command?command=' + command,
     headers: { 'Authorization': 'Bearer ' + token },
     success: logSuccess,
     error: logError

--- a/server/TODO
+++ b/server/TODO
@@ -1,6 +1,9 @@
 X Make buttons bigger
 X Add client authentication
-Add basic robot authentication
+X Add basic robot authentication
+  Emulate full remo.tv auth sequence
+  Add support for the TTS
+  Add the capability to gate a command to only people with certain roles
 
 Deploy server to cloud
 Get the extension running on Twitch

--- a/server/TODO
+++ b/server/TODO
@@ -1,7 +1,7 @@
 X Make buttons bigger
 X Add client authentication
-X Add basic robot authentication
-  Emulate full remo.tv auth sequence
+  Add basic robot authentication
+X Emulate remo.tv auth sequence (make robot trust server)
   Add support for the TTS
   Add the capability to gate a command to only people with certain roles
 

--- a/server/config.sample.conf
+++ b/server/config.sample.conf
@@ -1,0 +1,26 @@
+#Use the token_gen.py script to generate a token.
+
+[crypto]
+# The 'encryption' config accepts these options:
+#   force_both - encrypt outbound messages and decrypt inbound ones
+#   force_in   - decrypt inbound messages but don't encrypt outbound ones
+#   force_out  - encrypt outbound messages but don't decrypt inbound ones
+#   none       - don't encrypt outbound messages and don't decrypt inbound ones
+encryption = none
+
+#The token used to encrypt outbound messages and decrypt inbound ones
+token = put_crypto_token_here
+
+
+[server]
+#The server address
+address = localhost:8000
+
+
+[twitch]
+#The Twitch extension secret Key
+ext_secret = put_Twitch_extension_key_here
+
+#The Twitch stream Key
+#(It will only be sent to the robot if outbound messages are encrypted)
+stream_key = put_Twitch_stream_key_here

--- a/server/config.sample.conf
+++ b/server/config.sample.conf
@@ -1,22 +1,3 @@
-#Use the token_gen.py script to generate a token.
-
-[crypto]
-# The 'encryption' config accepts these options:
-#   force_both - encrypt outbound messages and decrypt inbound ones
-#   force_in   - decrypt inbound messages but don't encrypt outbound ones
-#   force_out  - encrypt outbound messages but don't decrypt inbound ones
-#   none       - don't encrypt outbound messages and don't decrypt inbound ones
-encryption = none
-
-#The token used to encrypt outbound messages and decrypt inbound ones
-token = put_crypto_token_here
-
-
-[server]
-#The server address
-address = localhost:8000
-
-
 [twitch]
 #The Twitch extension secret Key
 ext_secret = put_Twitch_extension_key_here

--- a/server/config.sample.conf
+++ b/server/config.sample.conf
@@ -1,7 +1,9 @@
+[server]
+# secret key used to sign an validate the robot tokens
+#   if this is not set correctly token-gen.py will generate one
+#   if this is set correctly token-gen.py will use it
+secret_key = put_key_generated_by_token-gen.py_here
+
 [twitch]
 #The Twitch extension secret Key
 ext_secret = put_Twitch_extension_key_here
-
-#The Twitch stream Key
-#(It will only be sent to the robot if outbound messages are encrypted)
-stream_key = put_Twitch_stream_key_here

--- a/server/quartapp.py
+++ b/server/quartapp.py
@@ -45,8 +45,6 @@ try:
       print("Error: Invalid token,", sys.exc_info()[1])
       sys.exit()
 
-  server_address = config.get('server', 'address')
-
   secret = os.getenv("TWITCH_SECRET_KEY", None)
   if secret is None:
     secret_code = config.get('twitch', 'ext_secret')
@@ -131,6 +129,20 @@ async def root():
   return 'OK'
 
 
+@app.route('/api/dev/channels/list/strangeparts')
+async def channels_list():
+  j = json.dumps({
+    "channels": [
+      {
+        "name": "SpareParts",
+        "id": "marionette-SpareParts",
+        "chat": "daspareparts"
+      }
+    ]
+  })
+  return j
+
+
 @app.route('/command')
 async def command():
   c = request.args.get('command')
@@ -169,7 +181,7 @@ async def process_message(message):
     j = json.dumps({
       'e': 'ROBOT_VALIDATED',
       'd': {
-        'host': server_address,
+        'host': 'strangeparts',
         'stream_key': stream_key,
       },
     })

--- a/server/quartapp.py
+++ b/server/quartapp.py
@@ -92,4 +92,5 @@ async def process_message(websocket, message):
     await websocket.send(j)
 
 if __name__ == "__main__":
-  app.run(host='0.0.0.0')
+  app.run(host='0.0.0.0',port=8000)
+  

--- a/server/quartapp.py
+++ b/server/quartapp.py
@@ -39,7 +39,6 @@ except(IOError, FileNotFoundError):
   print("Unable to read robots.json, check that it exists and that the program has permission to read it.")
   sys.exit()
 
-
 try:
   # To read values from config:
   # value = config.get('section', 'key')
@@ -100,18 +99,22 @@ async def root():
   return 'OK'
 
 
-@app.route('/api/dev/channels/list/strangeparts')
-async def channels_list():
-  j = json.dumps({
-    "channels": [
-      {
-        "name": "SpareParts",
-        "id": "channel_SpareParts",
-        "chat": "daspareparts"
-      }
-    ]
-  })
-  return j
+@app.route('/api/dev/channels/list/<host>')
+async def channels_list(host):
+  chanlist = []
+  try:
+    for rid in robots_config[host]:
+      chanlist.append({
+        "name": robots_config[host][rid]["info"]["name"],
+        "id": rid,
+        "chat": robots_config[host][rid]['info']['chat']
+      })
+  except KeyError:
+    response = Response('')
+    response.status_code = 404
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
+  return {"channels": chanlist}
 
 
 @app.route('/command')

--- a/server/quartapp.py
+++ b/server/quartapp.py
@@ -80,7 +80,8 @@ async def sending(queue):
     data = await queue.get()
     await websocket_send(data)
 
-async def receiving(queue):
+
+async def receiving():
   while True:
     data = await websocket.receive()
     if encryption == 'force_both' or encryption == 'force_in':
@@ -118,7 +119,7 @@ async def broadcast(message):
 @collect_websocket
 async def ws(queue):
   producer = asyncio.create_task(sending(queue))
-  consumer = asyncio.create_task(receiving(queue))
+  consumer = asyncio.create_task(receiving())
   await asyncio.gather(producer, consumer)
 
 @app.route('/')

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,3 +2,5 @@ quart
 quart-cors
 pyjwt
 websocket_client
+configparser
+cryptography

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,4 +3,3 @@ quart-cors
 pyjwt
 websocket_client
 configparser
-cryptography

--- a/server/token-gen.py
+++ b/server/token-gen.py
@@ -1,0 +1,97 @@
+# python token-gen.py --id=robotid --name=robotname --chat=chatchanelname --streamkey=twitch_stream_key servername
+
+import time
+from cryptography.fernet import Fernet
+import jwt
+import getopt
+import json
+import sys
+from configparser import ConfigParser, NoSectionError, NoOptionError
+
+argv = sys.argv[1:]
+opts, args = getopt.getopt(argv, shortopts='', longopts=['id=', 'name=', 'chat=', 'streamkey='])
+robot = {}
+robots = {}
+
+
+def key_gen():
+  return Fernet.generate_key()
+
+
+def token_gen(secret, payload):
+  payload["iat"] = int(time.time())
+  # print("payload: " + str(payload))
+  return jwt.encode(payload, secret, algorithm='HS256')
+
+
+for option in opts:
+  robot[option[0][2:]] = option[1]
+
+robot["host"] = args[0]
+
+try:
+  with open('robots.json', 'r') as filepointer:
+    robots = json.load(filepointer)
+    filepointer.close()
+except(IOError, FileNotFoundError):
+  try:
+    with open('robots.json', 'w') as filepointer:
+      json.dump(robots, filepointer, indent=4)
+      filepointer.close()
+  except(IOError, FileNotFoundError):
+    print("Unable to write robots.json, check that you have permission to write in the directory.")
+    sys.exit()
+
+config = ConfigParser()
+try:
+  with open('config.conf', 'r') as filepointer:
+    config.read_file(filepointer)
+  filepointer.close()
+except(IOError, FileNotFoundError):
+  print("Unable to read config.conf, check that it exists and that the program has permission to read it.")
+  sys.exit()
+
+try:
+  key = config.get('server', 'secret_key')
+
+except(NoSectionError, NoOptionError):
+  print("Error in config.conf:", sys.exc_info()[1])
+  sys.exit()
+
+if (len(key) != 44) or (key[-1:] != "="):
+  key = str(key_gen())[2:46]
+
+print("Key: " + key)
+token = token_gen(key, robot)
+print("Token: " + token)
+
+try:
+  t = robot['streamkey']
+except KeyError:
+  robot['streamkey'] = "Twitch stream Key not set"
+
+print("Robot data: " + str(robot))
+if robots == {}:
+  robots[args[0]] = {}
+elif robots == "":
+  robots = {args[0]: {}}
+
+robots[args[0]][robot["id"]] = \
+  {
+    "token": token,
+    "info": {
+      "name": robot["name"],
+      "chat": robot["chat"],
+      "stream_key": robot['streamkey']
+    }
+  }
+
+try:
+  with open('robots.json', 'w') as filepointer:
+    json.dump(robots, filepointer, indent=4)
+    filepointer.close()
+except(IOError, FileNotFoundError):
+  print("Unable to write robots.json, check that you have permission to write in the directory.")
+  sys.exit()
+
+print("robots.json updated")

--- a/server/token_gen.py
+++ b/server/token_gen.py
@@ -1,0 +1,4 @@
+from cryptography.fernet import Fernet
+def token_gen():
+  print (str(Fernet.generate_key())[2:46])
+token_gen()

--- a/server/token_gen.py
+++ b/server/token_gen.py
@@ -1,4 +1,0 @@
-from cryptography.fernet import Fernet
-def token_gen():
-  print (str(Fernet.generate_key())[2:46])
-token_gen()


### PR DESCRIPTION
The server now validates the robot token
The server now requires that the viewer sending commands be logged in to Twitch
The server now correctly responds to the full sequence to fool the robot that it's connecting to a remo.tv compatible server

I had temporally added encryption to the web-sockets messaging but later removed it because it would require changes to the robot's controller code, and I though that for now requiring as few changes as possible to make it easier to change between using marionette and using remo.tv to be better. I can always add it back later.

This code (the original code also does this) currently does one thing incorrectly in my opinion, it can't send the command messages to just the robot, it will broadcast those to everyone who is connected to the web-socket, I couldn't thing a way to fix that, commit c7f74ad was an attempt at that but it failed to work during testing, I did some other tests but tested those before making a commit and could not find anything that would work.